### PR TITLE
[Bugfix] Variable head_size by num_attention_heads attribute

### DIFF
--- a/BERT/python/bert_op/torch/bert_op_torch.py
+++ b/BERT/python/bert_op/torch/bert_op_torch.py
@@ -16,7 +16,7 @@ class BertEncoderOp(transformers.models.bert.modeling_bert.BertEncoder):
     """
 
     class BertEncoderScriptModule(torch.nn.Module):
-        def __init__(self, max_position_embeddings, hidden_size, intermediate_size, num_hidden_layers,
+        def __init__(self, max_position_embeddings, hidden_size, intermediate_size, num_hidden_layers, num_att_heads,
                      use_quantization, use_bfloat16, quantization_factors, calibrate_quant_factors,
                      params):
             super().__init__()
@@ -26,6 +26,7 @@ class BertEncoderOp(transformers.models.bert.modeling_bert.BertEncoder):
             self.hidden_size = hidden_size
             self.intermediate_size = intermediate_size
             self.num_hidden_layers = num_hidden_layers
+            self.num_att_heads = num_att_heads
             self.use_quantization = use_quantization
             self.use_bfloat16 = use_bfloat16
             # Convert from numpy array to list, to make it work with torchscript
@@ -44,6 +45,7 @@ class BertEncoderOp(transformers.models.bert.modeling_bert.BertEncoder):
                                        self.intermediate_size,
                                        batch_size,
                                        self.num_hidden_layers,
+                                       self.num_att_heads,
                                        self.use_quantization, self.use_bfloat16, self.calibrate_quant_factors)
                 self.bert_op.initialize(self.params, self.quantization_factors)
                 self._initialized = True
@@ -70,6 +72,7 @@ class BertEncoderOp(transformers.models.bert.modeling_bert.BertEncoder):
             self.config.hidden_size,
             self.config.intermediate_size,
             self.config.num_hidden_layers,
+            self.config.num_attention_heads,
             self.config.use_quantization, self.config.use_bfloat16, self.config.quantization_factors,
             self.config.calibrate_quant_factors,
             [*self.parameters()])

--- a/BERT/src/bert_layer/bert_layer_quant_int8.h
+++ b/BERT/src/bert_layer/bert_layer_quant_int8.h
@@ -30,7 +30,7 @@
 
 class BertLayer
 {
-    using InnerProductPrimT = dnnl::convolution_forward;
+    using InnerProductPrimT = dnnl::inner_product_forward;
 
     static dnnl::memory::data_type DataQuantizationType(const std::shared_ptr<BertContext>& ctx) {
         return dnnl_wrappers::AsymQuantizationSupported<InnerProductPrimT>()

--- a/BERT/src/pytorch_op/CMakeLists.txt
+++ b/BERT/src/pytorch_op/CMakeLists.txt
@@ -13,12 +13,6 @@ list(APPEND CMAKE_PREFIX_PATH ${PYTORCH_CMAKE_PREFIX_PATH})
 
 find_package(Torch)
 find_package(dnnl REQUIRED)
-
-# NOTE: (krzychut)
-# Not sure why, but libBertOpPT.so wants to link to libmkl_intel_thread.so.2, even if I remove DNNL from this target.
-# Without linking to MKL libs, I get an undefined symbol error from the BertOp.
-# None of the pytorch libs (libtoch.so, libtoch_cpu.so etc.) or other libs reported by `ldd` seem to link to MKL. 
-find_package(MKL REQUIRED)
 find_package(OpenMP REQUIRED)
 
 include_directories(
@@ -27,17 +21,15 @@ include_directories(
 
 add_library(${TARGET} SHARED ${SOURCES})
 
-set_target_properties(${TARGET} PROPERTIES
-    CXX_STANDARD_REQUIRED TRUE
-    CXX_STANDARD 14)
+# set_target_properties(${TARGET} PROPERTIES
+#     CXX_STANDARD_REQUIRED TRUE
+#     CXX_STANDARD 14)
 
 target_link_libraries(${TARGET} PUBLIC BertLayer)
 
 target_link_libraries(${TARGET} PUBLIC DNNL::dnnl)
 
 target_link_libraries(${TARGET} PUBLIC ${TORCH_LIBRARIES})
-
-target_link_libraries(${TARGET} PUBLIC MKL::MKL)
 
 target_link_libraries(${TARGET} PUBLIC ${OpenMP_gomp_LIBRARY} PUBLIC ${OpenMP_pthread_LIBRARY})
 target_compile_options(${TARGET} PUBLIC ${OpenMP_CXX_FLAGS})

--- a/BERT/src/pytorch_op/bert_op.cpp
+++ b/BERT/src/pytorch_op/bert_op.cpp
@@ -74,11 +74,11 @@ private:
 }
 
 void BertOp::Configure(int64_t max_seq_len = 128, int64_t hidden_size = 768, int64_t intermediate_size = 3072, int64_t batch_size = 1,
-                int64_t num_layers = 12, bool use_quantization = false, bool use_bfloat16 = false,
+                int64_t num_layers = 12, int64_t num_att_heads = 12, bool use_quantization = false, bool use_bfloat16 = false,
                 bool calibrate_quant_factors = false)
 {
     context_ = std::make_shared<BertContext>(max_seq_len, hidden_size, intermediate_size, batch_size, num_layers,
-                                                  use_quantization, use_bfloat16, calibrate_quant_factors);
+                                             num_att_heads, use_quantization, use_bfloat16, calibrate_quant_factors);
 
     layers_.reserve(num_layers);
     for(int i = 0; i < num_layers; ++i)

--- a/BERT/src/pytorch_op/bert_op.hpp
+++ b/BERT/src/pytorch_op/bert_op.hpp
@@ -24,7 +24,8 @@ class BertOp : public torch::CustomClassHolder {
 
 public:
     void Configure(int64_t max_seq_len, int64_t hidden_size, int64_t intermediate_size, int64_t batch_size,
-                   int64_t num_layers, bool use_quantization, bool use_bfloat16, bool calibrate_quant_factors);
+                   int64_t num_layers, int64_t num_att_heads, bool use_quantization, bool use_bfloat16,
+                   bool calibrate_quant_factors);
 
     std::vector<double> GetQuantizationFactors() const;
 

--- a/BERT/src/tf_op/bert_op.cpp
+++ b/BERT/src/tf_op/bert_op.cpp
@@ -90,8 +90,8 @@ public:
             OP_REQUIRES_OK(context, context->GetAttr("NumAttentionHeads", &num_attention_heads));
             OP_REQUIRES(context, num_attention_heads > 0, errors::InvalidArgument("NumAttentionHeads must be greater than 0."));
 
-            OP_REQUIRES(context, num_attention_heads * BertContext::head_size == hidden_size,
-                errors::InvalidArgument("Constraint not met: HiddenSize = NumAttentionHead * HeadSize"));
+            OP_REQUIRES(context, hidden_size % num_attention_heads == 0,
+                errors::InvalidArgument("Constraint not met: HiddenSize % NumAttentionHead == 0"));
 
             int layers = num_weights / BertContext::tensors_per_layer;
 

--- a/BERT/tests/benchmark/benchmark.cpp
+++ b/BERT/tests/benchmark/benchmark.cpp
@@ -116,7 +116,7 @@ void benchmark(float *input, const Config& config)
 {
   using dt = dnnl::memory::data_type;
 
-  auto ctx = std::make_shared<BertContext>(config.maxTokenSize, config.hiddenSize, config.intermediateSize, config.batch, config.layers, config.do_quant, config.do_bf16);
+  auto ctx = std::make_shared<BertContext>(config.maxTokenSize, config.hiddenSize, config.intermediateSize, config.batch, config.layers, config.attentionHeadNum, config.do_quant, config.do_bf16);
   std::vector<std::unique_ptr<BertLayer>> bert_layers(config.layers);
   std::vector<QuantizationFactors> quant_factors;
   if (config.layers == 12) {


### PR DESCRIPTION
Add support for `num_attention_heads` attribute to support variadic set of embedding models.